### PR TITLE
minor correction to "silly years" specs

### DIFF
--- a/Javascript/spec/algorithms_spec.js
+++ b/Javascript/spec/algorithms_spec.js
@@ -94,12 +94,12 @@ describe("lcs", function() {
 
 describe("sillyYears", function() {
   it("should return the ten subsequent silly years", function() {
-    var array = [1978, 2307, 2417, 2527, 2637, 2747, 2857, 2967, 3406, 3516]
+    var array = [2307, 2417, 2527, 2637, 2747, 2857, 2967, 3406, 3516, 3626]
     expect(Algorithms.sillyYears(1978)).toEqual(array);
   });
 
   it("should return the ten subsequent silly years", function() {
-    var array = [2307, 2417, 2527, 2637, 2747, 2857, 2967, 3406, 3516, 3626]
+    var array = [2417, 2527, 2637, 2747, 2857, 2967, 3406, 3516, 3626, 3736]
     expect(Algorithms.sillyYears(2307)).toEqual(array);
   });
 });

--- a/Ruby/spec/algorithms_spec.rb
+++ b/Ruby/spec/algorithms_spec.rb
@@ -109,12 +109,12 @@ end
 
 describe 'silly_years' do
   it 'should return the ten subsequent silly years' do
-    array = [1978, 2307, 2417, 2527, 2637, 2747, 2857, 2967, 3406, 3516]
+    array = [2307, 2417, 2527, 2637, 2747, 2857, 2967, 3406, 3516, 3626]
     expect(silly_years(1978)).to match_array(array)
   end
 
   it 'should return the ten subsequent silly years' do
-    array = [2307, 2417, 2527, 2637, 2747, 2857, 2967, 3406, 3516, 3626]
+    array = [2417, 2527, 2637, 2747, 2857, 2967, 3406, 3516, 3626, 3736]
     expect(silly_years(2307)).to match_array(array)
   end
 end


### PR DESCRIPTION
The problem statement specifies that the ten *subsequent* silly years
should be returned. In other words, the initial year that is passed to
the "silly years" function should not be included in the result.