### PR TITLE
make subsets spec less picky

### DIFF
--- a/Ruby/spec/algorithms_spec.rb
+++ b/Ruby/spec/algorithms_spec.rb
@@ -183,11 +183,12 @@ end
 
 describe 'subsets' do
   it 'should return the subsets of a given array' do
-    array = [[], [3], [2], [3, 2], [1], [3, 1], [2, 1], [3, 2, 1]]
-    expect(subsets([1, 2, 3])).to match_array(array)
+    array = [[], [1], [2], [3], [1, 2], [1, 3], [2, 3], [1, 2, 3]]
+    # sort each subset so that differently ordered subsets still pass
+    expect(subsets([1, 2, 3]).map(&:sort)).to match_array(array)
   end
 
-  it 'should return a set containing an empty set if given and empty set' do
+  it 'should return a set containing an empty set if given an empty set' do
     array = [[]]
     expect(subsets([])).to match_array(array)
   end


### PR DESCRIPTION
The ordering of elements within a subset should not be considered to be
significant. So a subset of [1, 2] should be considered equivalent to a
subset of [2, 1]. By sorting each of the user's subsets, and by
providing an expected set of subsets where the subsets are each sorted,
the spec is made to be less sensitive to inconsequential implementation
details.