### PR TITLE
Correct 'common substrings' spec

### DIFF
--- a/Javascript/spec/algorithms_spec.js
+++ b/Javascript/spec/algorithms_spec.js
@@ -23,8 +23,8 @@ describe("commonSubstrings", function() {
     expect(Algorithms.commonSubstrings('Hello', 'Hello World')).toBe(5);
   });
 
-  it("'ABABC' and 'BABCA' should return 'ABC'", function() {
-    expect(Algorithms.commonSubstrings('ABABC', 'BABCA')).toBe(3);
+  it("'ABABC' and 'BABCA' should return 'BABC'", function() {
+    expect(Algorithms.commonSubstrings('ABABC', 'BABCA')).toBe(4);
   });
 });
 


### PR DESCRIPTION
The longest common substring for 'ABABC' and 'BABCA' is actually 'BABC' with a length of 4. 