### PR TITLE
Reference iterative_factorial rather than recursive_factorial in spec

### DIFF
--- a/Ruby/spec/iterative_factorial_spec.rb
+++ b/Ruby/spec/iterative_factorial_spec.rb
@@ -1,14 +1,15 @@
 require "iterative_factorial"
 
 describe "iterative_factorial" do
-  specify { expect(recursive_factorial(0)).to eq(1) }
-  specify { expect(recursive_factorial(1)).to eq(1) }
-  specify { expect(recursive_factorial(3)).to eq(6) }
-  specify { expect(recursive_factorial(5)).to eq(120) }
+  specify { expect(iterative_factorial(0)).to eq(1) }
+  specify { expect(iterative_factorial(1)).to eq(1) }
+  specify { expect(iterative_factorial(3)).to eq(6) }
+  specify { expect(iterative_factorial(5)).to eq(120) }
 
   it "does not call itself" do
-    expect(self).to_not receive(:iterative_factorial)
-      .at_least(:twice).and_call_original
-    recursive_factorial(10)
+    allow(self).to receive(:iterative_factorial).at_least(:once).and_call_original
+    iterative_factorial(10)
+
+    expect(self).to have_received(:iterative_factorial).exactly(:once)
   end
 end


### PR DESCRIPTION
Also, fix the RSpec expectation for the number of `#iterative_factorial` method calls, since RSpec does not support specifying a certain number of method calls (in this case, a number of method calls greater than or equal to two) with negative message expectations.

Prior to this change, even after implementing `#iterative_factorial` correctly, the `Ruby/spec/iterative_factorial_spec.rb` specs would still fail with these error messages:

```
Failures:

  1) iterative_factorial
     Failure/Error: specify { expect(recursive_factorial(0)).to eq(1) }

     NoMethodError:
       undefined method `recursive_factorial' for #<RSpec::ExampleGroups::IterativeFactorial "example at ./spec/iterative_factorial_spec.rb:4">
     # ./spec/iterative_factorial_spec.rb:4:in `block (2 levels) in <top (required)>'

[...]

  5) iterative_factorial does not call itself
     Failure/Error:
       expect(self).to_not receive(:iterative_factorial)
         .at_least(:twice).and_call_original

     RuntimeError:
       `count` is not supported with negative message expectations
     # ./spec/iterative_factorial_spec.rb:10:in `block (2 levels) in <top (required)>'

Finished in 0.03218 seconds (files took 0.42977 seconds to load)
5 examples, 5 failures
```

With this change, the specs all pass when `#iterative_factorial` has been implemented correctly.

<details>
<summary>SPOILER: click to see an implementation of <code>#iterative_factorial</code></summary>
  
```rb
def iterative_factorial(number)
  product = 1
  (2..number).each do |factor|
    product *= factor
  end
  product
end
```
</details>