### PR TITLE
Make common_subsets spec independent of subset ordering

### DIFF
--- a/Ruby/spec/common_subsets_spec.rb
+++ b/Ruby/spec/common_subsets_spec.rb
@@ -4,14 +4,16 @@ describe "common_subsets" do
   it "should return the common subsets of two arrays" do
     array_one = [1, 2, 3, 4, 5]
     array_two = [2, 3, 4]
-    subsets = [[], [4], [3], [4, 3], [2], [4, 2], [3, 2], [4, 3, 2]]
-    expect(common_subsets(array_one, array_two)).to eq(subsets)
+    actual_subsets = common_subsets(array_one, array_two).map(&:sort)
+    expected_subsets = [[], [4], [3], [3, 4], [2], [2, 4], [2, 3], [2, 3, 4]]
+    expect(actual_subsets).to match_array(expected_subsets)
   end
 
   it "should return the common subsets of two arrays" do
     array_one = [1, 3, 5, 7, 9]
     array_two = [2, 4, 5, 6, 8]
-    subsets = [[], [5]]
-    expect(common_subsets(array_one, array_two)).to eq(subsets)
+    actual_subsets = common_subsets(array_one, array_two).map(&:sort)
+    expected_subsets = [[], [5]]
+    expect(actual_subsets).to match_array(expected_subsets)
   end
 end


### PR DESCRIPTION
(Related context: This PR makes the same change for the #common_subsets problem that #8 / 7a79bd3 made for the #subsets problem.)

The ordering of elements within a subset should not be considered to be significant, e.g. a subset of [1, 2] should be considered equivalent to a subset of [2, 1]. By sorting each of the user's returned subsets, and by providing an expected list of subsets where the elements of the subsets are sorted, the spec is made to be less sensitive to inconsequential implementation details.

Similarly, the ordering of the subsets should not be considered to be significant, e.g. `[[], [5]]` and `[[5], []]` should both pass. This change accomplishes that by using `match_array` rather than `eq`.

Thanks for the great library, Jayson! Things are good with me, and I hope that all is well with you, too!