### PR TITLE
Make language selection sticky across problems (fix #53)

### DIFF
--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -43,7 +43,7 @@ export default function Workspace({
   // Resolve the initial language once (Workspace remounts per problem.key).
   const initialLangRef = useRef<Language | null>(null);
   if (initialLangRef.current === null) {
-    initialLangRef.current = lastLanguage(problem.key) ?? 'javascript';
+    initialLangRef.current = lastLanguage() ?? 'javascript';
   }
   const initialLang = initialLangRef.current;
 
@@ -149,7 +149,7 @@ export default function Workspace({
     setCode(seed);
     editorRef.current?.reset(seed);
     setResult(null);
-    saveLastLanguage(problem.key, next);
+    saveLastLanguage(next);
     ensureRuntime(next);
   };
 

--- a/src/data/storage.test.ts
+++ b/src/data/storage.test.ts
@@ -73,14 +73,15 @@ describe('vim preference', () => {
 });
 
 describe('last language', () => {
-  it('round-trips and validates against the Language union', () => {
-    expect(lastLanguage('two_sum')).toBeNull();
-    saveLastLanguage('two_sum', 'ruby');
-    expect(lastLanguage('two_sum')).toBe('ruby');
-    saveLastLanguage('two_sum', 'python');
-    expect(lastLanguage('two_sum')).toBe('python');
-    localStorage.setItem('pta:lang:two_sum', 'cobol');
-    expect(lastLanguage('two_sum')).toBeNull();
+  it('round-trips globally and validates against the Language union', () => {
+    expect(lastLanguage()).toBeNull();
+    saveLastLanguage('ruby');
+    expect(lastLanguage()).toBe('ruby');
+    expect(localStorage.getItem('pta:lang')).toBe('ruby');
+    saveLastLanguage('python');
+    expect(lastLanguage()).toBe('python');
+    localStorage.setItem('pta:lang', 'cobol');
+    expect(lastLanguage()).toBeNull();
   });
 });
 
@@ -99,6 +100,6 @@ describe('resilience when localStorage throws', () => {
     expect(solvedLanguages('two_sum')).toEqual([]);
     expect(loadHintCount('two_sum')).toBe(0);
     expect(loadVimPref()).toBe(false);
-    expect(lastLanguage('two_sum')).toBeNull();
+    expect(lastLanguage()).toBeNull();
   });
 });

--- a/src/data/storage.ts
+++ b/src/data/storage.ts
@@ -88,14 +88,14 @@ export function saveVimPref(enabled: boolean): void {
   safeSet(VIM_KEY, enabled ? '1' : '0');
 }
 
-// --- Last selected language (resume UX) ----------------------------------
-const langKey = (problemKey: string) => `${PREFIX}lang:${problemKey}`;
+// --- Last selected language (global; sticky across problems) -------------
+const LANG_KEY = `${PREFIX}lang`;
 
-export function lastLanguage(problemKey: string): Language | null {
-  const raw = safeGet(langKey(problemKey));
+export function lastLanguage(): Language | null {
+  const raw = safeGet(LANG_KEY);
   return isLanguage(raw) ? raw : null;
 }
 
-export function saveLastLanguage(problemKey: string, lang: Language): void {
-  safeSet(langKey(problemKey), lang);
+export function saveLastLanguage(lang: Language): void {
+  safeSet(LANG_KEY, lang);
 }

--- a/tests/e2e/persistence.spec.ts
+++ b/tests/e2e/persistence.spec.ts
@@ -59,6 +59,24 @@ test('persists revealed hints across reload', async ({ page }) => {
   await expect(page.locator('.hint-item')).toHaveCount(2);
 });
 
+test('language selection is sticky across problems', async ({ page }) => {
+  await page.goto('/');
+
+  // Select Python on one problem.
+  await page.getByRole('button', { name: /Two Sum/ }).click();
+  const python = page.getByRole('button', { name: /Python/ });
+  await python.click();
+  await expect(python).toHaveAttribute('aria-pressed', 'true');
+
+  // Open a different problem → Python is already selected there.
+  await page.getByRole('button', { name: /All problems/ }).click();
+  await page.getByRole('button', { name: /Maximum Subarray/ }).click();
+  await expect(page.getByRole('button', { name: /Python/ })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+});
+
 test('persists the Vim preference across reload', async ({ page }) => {
   await page.goto('/');
   await page.getByRole('button', { name: /Two Sum/ }).click();


### PR DESCRIPTION
## Summary

Closes #53. Language selection is now **globally sticky**: pick a language on one problem and it's already selected when you open any other problem.

Previously the chosen language was remembered **per problem** (`pta:lang:<problemKey>`), so picking Python on one problem had no effect on the next problem you opened — it fell back to the default JavaScript.

## Changes

- **`src/data/storage.ts`** — promote "last selected language" from a per-problem key to a single global key (`pta:lang`), mirroring the existing global Vim-preference pattern. `lastLanguage()` / `saveLastLanguage(lang)` now take no `problemKey`.
- **`src/components/Workspace.tsx`** — update the two call sites to the global signatures.
- **`src/data/storage.test.ts`** — update the "last language" unit test to the global API.
- **`tests/e2e/persistence.spec.ts`** — add an end-to-end test asserting Python selected on Two Sum carries over to Maximum Subarray.

Per-(problem, language) **code** stays keyed independently, so revisiting a problem still restores the code written there in the active language — no code is lost.

## Verification

- `npm test` — 90/90 Vitest green.
- `npm run test:e2e` — 18/18 Playwright green, including the new sticky-selection test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)